### PR TITLE
Fix: Require empty hand for GUI access via shift-right-click

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A lightweight, simple chest locking plugin for Spigot 1.21+ servers. Lock chests
 - **Visual Feedback** - Particles and messages
 - **Admin Tools** - Admins can unlock any chest with override command
 - **High Performance** - Optimized database queries with indexes
-- **Easy Access** - Shift + Right-click to open GUI menu
+- **Easy Access** - Shift + Right-click (empty-handed) to open GUI menu
 - **Tab Completion** - Full autocomplete support for all commands
 
 ## Requirements
@@ -76,13 +76,13 @@ A lightweight, simple chest locking plugin for Spigot 1.21+ servers. Lock chests
 
 **Tab Completion:** All commands support tab completion! Press `TAB` to see available options.
 
-**GUI Access:** Shift + Right-click a chest to open the GUI menu!
+**GUI Access:** Shift + Right-click a chest (with empty hand) to open the GUI menu!
 
 ## Usage Examples
 
 ### Using the GUI (Recommended!)
 
-1. **Shift + Right-click** a chest (or use `/cl gui` while looking at one)
+1. **Shift + Right-click** a chest with an empty hand (or use `/cl gui` while looking at one)
 2. Click buttons in the menu to lock/unlock, set passwords, etc.
 3. Easy visual interface - no need to remember commands!
 
@@ -94,7 +94,7 @@ A lightweight, simple chest locking plugin for Spigot 1.21+ servers. Lock chests
 3. No command needed - just place and go!
 
 **Method 2: Using GUI**
-1. Shift + Right-click the chest (or `/cl gui`)
+1. Shift + Right-click the chest with an empty hand (or `/cl gui`)
 2. Click "Lock Chest" button
 
 **Method 3: Using Command**
@@ -114,7 +114,7 @@ Server: Tip: Use /cl password <password> to add password protection!
 
 **Method 1: Using GUI**
 1. Lock your chest first: `/cl lock` or via GUI
-2. Open GUI: Shift + Right-click chest
+2. Open GUI: Shift + Right-click chest (with empty hand)
 3. Click "Set Password" button
 4. Use the password input GUI to enter your password
 5. Click "Confirm Password" when done
@@ -133,7 +133,7 @@ Server: Password set successfully!
 
 **Method 1: Using GUI (for non-owners)**
 1. Look at a password-protected chest
-2. Shift + Right-click to open GUI
+2. Shift + Right-click with empty hand to open GUI
 3. Click "Enter Password" button
 4. Use the password input GUI to enter the password
 5. Click "Confirm Password" when done
@@ -166,7 +166,7 @@ The password is displayed in **real-time** as you build it, so you can see exact
 
 **Method 1: Using GUI (Recommended!)**
 1. Lock your chest first: `/cl lock` or via GUI
-2. Open GUI: Shift + Right-click chest
+2. Open GUI: Shift + Right-click chest (with empty hand)
 3. Click "Trusted Players" button
 4. Click "Add Trusted Player" button (or use `/cl trust <player>`)
 5. Click on a player head to remove trust
@@ -237,8 +237,9 @@ ChestLockLite includes a GUI menu for easy chest management.
 
 ### Opening the GUI
 
-- **Shift + Right-click** any chest (while sneaking)
+- **Shift + Right-click** any chest (while sneaking and empty-handed)
 - Or use `/cl gui` while looking at a chest
+- **Note:** You must have an empty hand to open the GUI via Shift + Right-click (prevents accidentally placing items)
 
 ### GUI Features
 
@@ -580,11 +581,12 @@ The plugin automatically detects all chest types using the `Chest` interface, ma
 - **All admin actions are logged to console** for security and audit purposes
 
 ### GUI System
-- Access via **Shift + Right-click** or `/cl gui`
+- Access via **Shift + Right-click** (with empty hand) or `/cl gui`
 - Shows different options based on lock status and permissions
 - Visual feedback with color-coded buttons
 - Admin override button only visible to admins
 - Password buttons adapt based on ownership and lock status
+- **Empty hand required** for Shift + Right-click to prevent accidental item placement
 
 ### Tab Completion
 - **First Argument**: Shows all available subcommands filtered by permissions
@@ -609,7 +611,7 @@ cd chestlocklite
 # Build with Maven
 mvn clean package
 
-# Find the jar in target/ChestLockLite-1.0.0.jar
+# Find the jar in target/ChestLockLite-1.0.1.jar
 ```
 
 ## Troubleshooting
@@ -634,6 +636,7 @@ mvn clean package
 - Make sure you have `chestlocklite.gui` permission
 - Try using `/cl gui` command instead of Shift + Right-click
 - Check if you're sneaking when using Shift + Right-click
+- **Make sure your hand is empty** - GUI only opens when holding nothing (prevents placing items)
 
 ### Password input GUI issues
 - Make sure you're clicking the character buttons correctly

--- a/RELEASE_NOTES_v1.0.1.md
+++ b/RELEASE_NOTES_v1.0.1.md
@@ -1,0 +1,41 @@
+# ChestLockLite v1.0.1 - Bug Fix Release
+
+## 🐛 Bug Fixes
+
+### GUI Access Fix
+- **Fixed:** GUI now only opens when player has an empty hand
+- **Issue:** Previously, shift-right-clicking with items (like chests or hoppers) would open the GUI instead of allowing item placement
+- **Solution:** Added empty-hand check before opening GUI via shift-right-click
+- **Impact:** Prevents accidentally placing chests next to chests or hoppers on chests when trying to open the GUI
+- **Note:** The `/cl gui` command still works even when holding items
+
+## 📝 Changes
+
+- Updated GUI access to require empty hand for shift-right-click method
+- Improved user experience by preventing accidental item placement
+- Documentation updated to reflect the empty-hand requirement
+
+## 🔄 Migration
+
+No migration needed - this is a bug fix that doesn't affect existing data or configuration.
+
+## 📚 Updated Documentation
+
+- README.md - Updated all GUI access instructions
+- wiki/GUI-Guide.md - Added empty-hand requirement details
+- wiki/Quick-Start.md - Updated GUI instructions
+
+## 📦 Download
+
+**Download**: [ChestLockLite-1.0.1.jar](https://github.com/eldor47/ChestLockLite/releases/download/v1.0.1/ChestLockLite-1.0.1.jar)
+
+## 🔗 Links
+
+- **Report Issues**: [GitHub Issues](https://github.com/eldor47/ChestLockLite/issues)
+- **Full Documentation**: [README.md](README.md)
+- **Wiki**: [GitHub Wiki](https://github.com/eldor47/ChestLockLite/wiki)
+
+---
+
+**Previous Version**: [v1.0.0 Release Notes](RELEASE_NOTES_v1.0.0.md)
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.chestlocklite</groupId>
     <artifactId>ChestLockLite</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>ChestLockLite</name>

--- a/src/main/java/com/chestlocklite/listeners/ChestListener.java
+++ b/src/main/java/com/chestlocklite/listeners/ChestListener.java
@@ -4,7 +4,6 @@ import com.chestlocklite.ChestLockLitePlugin;
 import com.chestlocklite.utils.MessageUtils;
 import com.chestlocklite.utils.PasswordHasher;
 import org.bukkit.block.Block;
-import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -19,6 +18,7 @@ import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.Material;
 import java.util.Iterator;
 import java.util.List;
 import java.util.HashMap;
@@ -59,8 +59,9 @@ public class ChestListener implements Listener {
             return;
         }
 
-        // Shift-right-click to open GUI
-        if (player.isSneaking() && player.hasPermission("chestlocklite.gui")) {
+        // Shift-right-click to open GUI (only if hand is empty)
+        if (player.isSneaking() && player.hasPermission("chestlocklite.gui") && 
+            player.getInventory().getItemInMainHand().getType() == Material.AIR) {
             org.bukkit.Location chestLocation = plugin.getLockManager().getPrimaryChestLocation(block);
             plugin.getLockGUI().openGUI(player, chestLocation);
             event.setCancelled(true);

--- a/wiki/GUI-Guide.md
+++ b/wiki/GUI-Guide.md
@@ -6,8 +6,9 @@ Complete guide to using the ChestLockLite GUI interface.
 
 ### Method 1: Sneak + Right-Click
 
-1. **Shift + Right-click** any chest (while sneaking)
+1. **Shift + Right-click** any chest (while sneaking and empty-handed)
 2. GUI opens automatically
+3. **Important:** You must have an empty hand - holding any item will prevent the GUI from opening (this prevents accidentally placing items like chests or hoppers)
 
 ### Method 2: Command
 
@@ -136,7 +137,8 @@ While GUI is open:
 
 **GUI won't open?**
 - Make sure you're sneaking when Shift + Right-clicking
-- Try `/cl gui` command instead
+- **Make sure your hand is empty** - holding any item prevents GUI from opening
+- Try `/cl gui` command instead (works even with items in hand)
 - Check `chestlocklite.gui` permission
 - Verify you're looking at a chest
 

--- a/wiki/Quick-Start.md
+++ b/wiki/Quick-Start.md
@@ -21,11 +21,13 @@ That's it! The chest is now locked to you.
 
 The GUI is the easiest way to manage your chests:
 
-1. **Shift + Right-click** any chest (while sneaking)
+1. **Shift + Right-click** any chest (while sneaking and empty-handed)
 2. Click the "Lock Chest" button
 3. Click "Set Password" if you want password protection
 
-Alternatively, use `/cl gui` while looking at a chest.
+**Note:** You must have an empty hand to open the GUI via Shift + Right-click. This prevents accidentally placing items like chests or hoppers.
+
+Alternatively, use `/cl gui` while looking at a chest (works even with items in hand).
 
 ## Adding Password Protection
 


### PR DESCRIPTION
- Added empty-hand check before opening GUI to prevent accidental item placement
- Updated version to 1.0.1
- Updated documentation (README, wiki) to reflect empty-hand requirement
- Added release notes for v1.0.1

Fixes issue where shift-right-clicking with items would open GUI instead of allowing item placement

Closes issues #1 #2 